### PR TITLE
dynamodbへinputとoutputを保存

### DIFF
--- a/packaged-template.yml
+++ b/packaged-template.yml
@@ -6,13 +6,14 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: translate-function-2
-      CodeUri: s3://sam-app-hands-on-yosnak-1/19162650045d10fcff8e28d87f6eb6cd
+      CodeUri: s3://sam-app-hands-on-yosnak-1/cc946d4b1ff29497264ca6cb182e1b6d
       Handler: translate-function.lambda_handler
       Runtime: python3.7
       Timeout: 5
       MemorySize: 256
       Policies:
       - TranslateFullAccess
+      - AmazonDynamoDBFullAccess
       Events:
         GetApi:
           Type: Api
@@ -27,3 +28,13 @@ Resources:
       Name: translate-api-2
       StageName: dev
       EndpointConfiguration: REGIONAL
+  TranslateDynamoDbTbl:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      TableName: translate-history-2
+      PrimaryKey:
+        Name: timestamp
+        Type: String
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1

--- a/template.yml
+++ b/template.yml
@@ -13,6 +13,7 @@ Resources:
       MemorySize: 256
       Policies:
         - TranslateFullAccess
+        - AmazonDynamoDBFullAccess
       Events:
         GetApi:
           Type: Api
@@ -26,3 +27,13 @@ Resources:
       Name: translate-api-2
       StageName: dev
       EndpointConfiguration: REGIONAL
+  TranslateDynamoDbTbl:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      TableName: translate-history-2
+      PrimaryKey:
+        Name: timestamp
+        Type: String
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1

--- a/translate-function/translate-function.py
+++ b/translate-function/translate-function.py
@@ -1,7 +1,10 @@
 import json
 import boto3
+import datetime
 
 translate = boto3.client(service_name = 'translate')
+
+dynamodb_translate_history_tbl = boto3.resource('dynamodb').Table('translate-history-2')
 
 def lambda_handler(event, context):
 
@@ -14,6 +17,14 @@ def lambda_handler(event, context):
   )
 
   output_text = response.get('TranslatedText')
+
+  dynamodb_translate_history_tbl.put_item(
+    Item = {
+      "timestamp": datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+      "input": input_text,
+      "output": output_text
+    }
+  )
 
   return {
     'statusCode': 200,


### PR DESCRIPTION
## やったこと

-  dynamodbテーブルのスタック追加
  - TableName: translate-history-2
- input_text、output_text、timestampをdynamodbに保存するよう関数修正